### PR TITLE
better http keep_alive logic

### DIFF
--- a/examples/test/epc_test.cpp
+++ b/examples/test/epc_test.cpp
@@ -80,7 +80,7 @@ void epc_test()
     {
       fiber::run_in_fiber([&mtx, &cond, &remaining, &epc, i] {
         for (int j = 0; j < 100; j++)
-          epc->with_connected_pipe([j](const pipe_t *pipe) {
+          epc->with_connected_pipe([j](const pipe_t *pipe) -> bool {
             const char *msg = "hello";
             //anon_log("sending " << j << "th epc test message \"" << msg << "\"");
             pipe->write(msg, strlen(msg) + 1);
@@ -89,6 +89,7 @@ void epc_test()
             while (!bytes_read || response[bytes_read - 1])
               bytes_read += pipe->read(&response[bytes_read], sizeof(response) - bytes_read);
             //anon_log("got back \"" << &response[0] << "\"");
+            return true;  // cache the socket
           });
 
         fiber_lock lock(mtx);

--- a/src/cpp/aws_http.cpp
+++ b/src/cpp/aws_http.cpp
@@ -98,7 +98,7 @@ public:
     auto message = str.str();
 
     auto read_body = method != HttpMethod::HTTP_HEAD;
-    get_epc(uri.GetURIString())->with_connected_pipe([this, &request, &resp, &message, read_body, readLimiter, writeLimiter, recursion](const pipe_t *pipe) {
+    get_epc(uri.GetURIString())->with_connected_pipe([this, &request, &resp, &message, read_body, readLimiter, writeLimiter, recursion](const pipe_t *pipe) -> bool {
       // anon_log("sending...\n\n" << message << "\n");
       pipe->write(message.c_str(), message.size());
       http_client_response re;
@@ -113,6 +113,7 @@ public:
         for (auto &data : re.body)
           resp->GetResponseBody().write(&data[0], data.size());
       }
+      return re.should_keep_alive;
     });
 
   }

--- a/src/cpp/epc.h
+++ b/src/cpp/epc.h
@@ -36,7 +36,7 @@ public:
   create(const char *host, int port,
          bool do_tls = false,
          const tls_context *tls_ctx = 0,
-         int max_conn_per_ep = 20,
+         int max_conn_per_ep = 40,
          int lookup_frequency_in_seconds = 20)
   {
     return std::make_shared<endpoint_cluster>(host, port, do_tls, tls_ctx, max_conn_per_ep, lookup_frequency_in_seconds);
@@ -53,7 +53,7 @@ public:
     max_io_block_time_ = max_io_block_time;
   }
 
-  void with_connected_pipe(const std::function<void(const pipe_t *pipe)> &f)
+  void with_connected_pipe(const std::function<bool(const pipe_t *pipe)> &f)
   {
     auto sleepMs = 50;
     auto slp = 0;
@@ -112,6 +112,7 @@ public:
       {
       }
       std::unique_ptr<pipe_t> pipe_;
+      timespec idle_start_time;
     };
 
     struct sockaddr_in6 addr_;
@@ -123,7 +124,7 @@ public:
   };
 
 private:
-  void do_with_connected_pipe(const std::function<void(const pipe_t *pipe)> &f);
+  void do_with_connected_pipe(const std::function<bool(const pipe_t *pipe)> &f);
   void update_endpoints();
 
 public:
@@ -150,6 +151,7 @@ private:
 
   enum
   {
-    k_default_io_block_time = 30
+    k_default_io_block_time = 30,
+    k_max_idle_time = 25
   };
 };

--- a/src/cpp/http_client.cpp
+++ b/src/cpp/http_client.cpp
@@ -279,6 +279,8 @@ void http_client_response::parse(const pipe_t &pipe, bool read_body)
 
     // response is good enough to return
     status_code = parser.status_code;
+    if (status_code >= 200 && status_code < 300)
+      should_keep_alive = http_should_keep_alive(&parser);
     break;
   }
 }

--- a/src/cpp/http_client.h
+++ b/src/cpp/http_client.h
@@ -29,7 +29,8 @@ struct http_client_response
 {
   http_client_response()
       : http_major_(0),
-        http_minor_(0)
+        http_minor_(0),
+        should_keep_alive(false)
   {
   }
 
@@ -38,6 +39,7 @@ struct http_client_response
   int status_code;
   http_headers headers;
   std::list<std::vector<char>> body;
+  bool should_keep_alive;
 
   void set_status(const char *ptr, size_t len) { status_ = std::string(ptr, len); }
   const std::string &get_status() const { return status_; }


### PR DESCRIPTION
handful of changes to improve basic keep_alive behavior.  tcp server and client can now better participate in whether the underlying endpoint_collection attempts to keep a socket open, and there is now a configurable "maximum idle time" beyond which the epc will not attempt to reuse an existing, previously open tcp connection.