### PR TITLE
force dns lookup after an server error response

### DIFF
--- a/src/cpp/epc.cpp
+++ b/src/cpp/epc.cpp
@@ -169,6 +169,12 @@ void endpoint_cluster::erase_if_empty(const std::shared_ptr<endpoint> &ep)
   erase(ep);
 }
 
+void endpoint_cluster::delete_cached_endpoints()
+{
+  fiber_lock l(mtx_);
+  endpoints_.resize(0);
+}
+
 namespace
 {
 

--- a/src/cpp/epc.h
+++ b/src/cpp/epc.h
@@ -69,6 +69,7 @@ public:
 
         if (sleepMs > 30 * 1000)
           throw;
+        delete_cached_endpoints();
         auto rid = small_rand_id();
         auto ri = *(unsigned int *)&rid.m_buf[0];
         slp = sleepMs * 3 / 4 + (ri % (sleepMs / 2));
@@ -126,6 +127,7 @@ public:
 private:
   void do_with_connected_pipe(const std::function<bool(const pipe_t *pipe)> &f);
   void update_endpoints();
+  void delete_cached_endpoints();
 
 public:
   void erase(const std::shared_ptr<endpoint> &ep);


### PR DESCRIPTION
Although not strictly necessary, there are cases we can have a lot of cached, open sockets to a particular IP address.  If the machine at the other end of that IP address starts returning 500 errors, it is generally an indication that all sockets connected to that machine will return 500's and there is a decent chance that a well implemented dns, load balancer will start returning different IP's if we re-lookup the IP address for the name we are using.

So this pr flushes any cached sockets and forces a dns lookup next time we try to connect to this endpoint cluster, if it hits any sort of "fiber io error" (which a 500 return is signaled as an io error).