### PR TITLE
let the aws-sdk layer handle all http retry logic

### DIFF
--- a/examples/teflon/main.cpp
+++ b/examples/teflon/main.cpp
@@ -37,38 +37,6 @@
 #include <aws/core/utils/threading/Executor.h>
 #include <aws/core/client/DefaultRetryStrategy.h>
 #include "aws_http.h"
-
-namespace
-{
-
-// we use this class to tell the AWS sdk to never try its
-// own retries.  All retry logic is done down in anon
-// and we don't want a second layer of it happening in AWS
-class neverRetryStrategy : public Aws::Client::DefaultRetryStrategy
-{
-public:
-  neverRetryStrategy()
-  {
-  }
-
-  bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &error, long attemptedRetries) const
-  {
-    return false;
-  }
-
-  long CalculateDelayBeforeNextRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &error, long attemptedRetries) const
-  {
-    return 0;
-  }
-};
-
-static std::shared_ptr<Aws::Client::RetryStrategy> make_strategy()
-{
-  return std::static_pointer_cast<Aws::Client::RetryStrategy>(std::make_shared<neverRetryStrategy>());
-}
-
-} // namespace
-
 #endif
 
 #include <dirent.h>
@@ -307,7 +275,6 @@ extern "C" int main(int argc, char **argv)
   if (region == "")
     region = "us-east-1";
 
-  client_cfg.retryStrategy = make_strategy();
   client_cfg.region = region;
   client_cfg.executor = aws_executor::singleton;
 #endif

--- a/src/cpp/epc.cpp
+++ b/src/cpp/epc.cpp
@@ -38,7 +38,8 @@ endpoint_cluster::endpoint_cluster(const char *host, int port,
       last_lookup_time_((struct timespec){}),
       round_robin_index_(0),
       looking_up_endpoints_(false),
-      max_io_block_time_(k_default_io_block_time)
+      max_io_block_time_(k_default_io_block_time),
+      retries_enabled_(true)
 {
 }
 

--- a/src/cpp/epc.h
+++ b/src/cpp/epc.h
@@ -53,6 +53,11 @@ public:
     max_io_block_time_ = max_io_block_time;
   }
 
+  void disable_retries()
+  {
+    retries_enabled_ = false;
+  }
+
   void with_connected_pipe(const std::function<bool(const pipe_t *pipe)> &f)
   {
     auto sleepMs = 50;
@@ -66,8 +71,8 @@ public:
       }
       catch (const fiber_io_error &e)
       {
-
-        if (sleepMs > 30 * 1000)
+        
+        if (!retries_enabled_ || sleepMs > 30 * 1000)
           throw;
         delete_cached_endpoints();
         auto rid = small_rand_id();
@@ -144,6 +149,7 @@ private:
 
   std::vector<std::shared_ptr<endpoint>> endpoints_;
   bool looking_up_endpoints_;
+  bool retries_enabled_;
   fiber_mutex mtx_;
   fiber_cond cond_;
   struct timespec last_lookup_time_;

--- a/src/cpp/http_client.cpp
+++ b/src/cpp/http_client.cpp
@@ -61,7 +61,7 @@ struct pc
 
 } // namespace
 
-void http_client_response::parse(const pipe_t &pipe, bool read_body)
+void http_client_response::parse(const pipe_t &pipe, bool read_body, bool throw_on_server_error)
 {
   // joyent data structure, set its callback functions
   http_parser_settings settings;
@@ -266,16 +266,18 @@ void http_client_response::parse(const pipe_t &pipe, bool read_body)
 #endif
       continue;
     }
-    if (parser.status_code == 408)
-      throw fiber_io_error("408 server response");
-    if (parser.status_code == 500)
-      throw fiber_io_error("500 server response");
-    if (parser.status_code == 502)
-      throw fiber_io_error("502 server response");
-    if (parser.status_code == 503)
-      throw fiber_io_error("503 server response");
-    if (parser.status_code == 504)
-      throw fiber_io_error("504 server response");
+    if (throw_on_server_error) {
+      if (parser.status_code == 408)
+        throw fiber_io_error("408 server response");
+      if (parser.status_code == 500)
+        throw fiber_io_error("500 server response");
+      if (parser.status_code == 502)
+        throw fiber_io_error("502 server response");
+      if (parser.status_code == 503)
+        throw fiber_io_error("503 server response");
+      if (parser.status_code == 504)
+        throw fiber_io_error("504 server response");
+    }
 
     // response is good enough to return
     status_code = parser.status_code;

--- a/src/cpp/http_client.h
+++ b/src/cpp/http_client.h
@@ -34,7 +34,7 @@ struct http_client_response
   {
   }
 
-  void parse(const pipe_t &pipe, bool read_body);
+  void parse(const pipe_t &pipe, bool read_body, bool throw_on_server_error = true);
 
   int status_code;
   http_headers headers;


### PR DESCRIPTION
In the case where an aws service returns a 5XX error it is generally better to allow the aws sdk layer to handle the retry instead of trying to handling down inside of anon itself.  One issue is that the crypto signature on the http message (in one of the headers) is time-sensitive, and so if anon does a simple "back off and retry" with these messages it can end up trying to resend the original message after the signature is no longer valid.

This pr allows optional behavior to the core pieces that were driving retry, and in the case where the aws_http layer is using these core pieces it turns off the retry logic - allowing the sdk to see the returned messages with the 5XX status code and related headers.