### PR TITLE
add helper fiber::schedule_task on top of io_dispatch::schedule_task

### DIFF
--- a/src/cpp/aws_sqs.cpp
+++ b/src/cpp/aws_sqs.cpp
@@ -76,19 +76,15 @@ void aws_sqs_listener::start()
       aws_sqs_listener::_simple_stack_size, "aws_sqs_listener::aws_sqs_listener, start_listen");
 
   #if defined(ANON_DEBUG_TIMERS)
-  anon_log("io_dispatch::schedule_task, aws_sqs_listener::start");
+  anon_log("fiber::schedule_task, aws_sqs_listener::start");
   #endif
-  _timer_task = io_dispatch::schedule_task(
-      [wp] {
-        fiber::run_in_fiber(
-            [wp] {
-              auto ths = wp.lock();
-              if (ths)
-                ths->set_visibility_timeout();
-            },
-            aws_sqs_listener::_simple_stack_size, "aws_sqs_listener, set_visibility_timeout sweeper");
+  _timer_task = fiber::schedule_task([wp] {
+        auto ths = wp.lock();
+        if (ths)
+          ths->set_visibility_timeout();
       },
-      cur_time() + visibility_sweep_time);
+      cur_time() + visibility_sweep_time,
+      aws_sqs_listener::_simple_stack_size, "aws_sqs_listener, set_visibility_timeout sweeper");
 }
 
 aws_sqs_listener::~aws_sqs_listener()
@@ -322,19 +318,15 @@ void aws_sqs_listener::set_visibility_timeout()
   // schedule the sweep to run again in visibility_sweep_time seconds
   std::weak_ptr<aws_sqs_listener> wp = shared_from_this();
   #if defined(ANON_DEBUG_TIMERS)
-  anon_log("io_dispatch::schedule_task, aws_sqs_listener::set_visibility_timeout");
+  anon_log("fiber::schedule_task, aws_sqs_listener::set_visibility_timeout");
   #endif
-  _timer_task = io_dispatch::schedule_task(
-      [wp] {
-        fiber::run_in_fiber(
-            [wp] {
-              auto ths = wp.lock();
-              if (ths)
-                ths->set_visibility_timeout();
-            },
-            aws_sqs_listener::_simple_stack_size, "aws_sqs_listener, set_visibility_timeout sweeper");
+  _timer_task = fiber::schedule_task([wp] {
+        auto ths = wp.lock();
+        if (ths)
+          ths->set_visibility_timeout();
       },
-      cur_time() + visibility_sweep_time);
+      cur_time() + visibility_sweep_time,
+      aws_sqs_listener::_simple_stack_size, "aws_sqs_listener, set_visibility_timeout sweeper");
 }
 
 void aws_sqs_listener::add_to_keep_alive(const Model::Message &m)

--- a/src/cpp/fiber.h
+++ b/src/cpp/fiber.h
@@ -281,6 +281,16 @@ public:
       f->fiber_name_ = new_name;
   }
 
+  static io_dispatch::scheduled_task schedule_task(const std::function<void(void)>& fn, const struct timespec &when,
+      size_t stack_size = k_default_stack_size, const char *fiber_name = "unknown3") {
+    std::string name = fiber_name;
+    return io_dispatch::schedule_task([fn, stack_size, name]{
+      run_in_fiber([fn] {
+        fn();
+      }, stack_size, name.c_str());
+    }, when);
+  }
+
 private:
   // a 'parent' -like fiber, illegal to call 'start' on one of these
   // this is the kind that live in io_params.iod_fiber_


### PR DESCRIPTION
I've made this mistake enough times that it is worth adding a helper function to schedule a task, where you want to run that task code from within a fiber context.  The raw io_dispatch::schedule_task is below the fiber layer of the design, so the function it is given is run in a raw os thread.  The new fiber version of this function takes an arbitrary callable function, but just wraps the fiber::run_in_fiber logic around the call to it.