### PR TITLE
first work on fiber-based ec2MetadataLoader

### DIFF
--- a/examples/teflon/main.cpp
+++ b/examples/teflon/main.cpp
@@ -39,6 +39,8 @@
 #include <aws/core/client/AWSError.h>
 #include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/platform/Environment.h>
+#include <aws/core/internal/AWSHttpResourceClient.h>
+#include <aws/core/utils/logging/LogMacros.h>
 #include "aws_http.h"
 #endif
 
@@ -82,6 +84,15 @@ static void show_help()
 #include "fiber.h"
 
 #ifdef TEFLON_AWS
+
+namespace Aws
+{
+    namespace Client
+    {
+        Aws::String ComputeUserAgentString();
+    }
+}
+
 namespace
 {
 class aws_executor : public Aws::Utils::Threading::Executor
@@ -120,66 +131,279 @@ public:
   }
 
   void Flush() override
-  {}
+  {
+  }
 };
 #endif
 
 class retryStrategy : public Aws::Client::DefaultRetryStrategy
 {
 public:
-    retryStrategy(long maxRetries = 10, long scaleFactor = 25)
-        : Aws::Client::DefaultRetryStrategy(maxRetries, scaleFactor)
+  retryStrategy(long maxRetries = 10, long scaleFactor = 25)
+      : Aws::Client::DefaultRetryStrategy(maxRetries, scaleFactor)
+  {
+  }
+
+#if EXTENSIVE_AWS_LOGS > 0
+  bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &error, long attemptedRetries) const
+  {
+    auto ret = Aws::Client::DefaultRetryStrategy::ShouldRetry(error, attemptedRetries);
+    if (ret)
+      anon_log("retryStrategy::ShouldRetry(\"" << error.GetExceptionName() << "\"," << attemptedRetries << ") returning true");
+    else
+      anon_log("retryStrategy::ShouldRetry(\"" << error.GetExceptionName() << "\"," << attemptedRetries << ") returning false, "
+                                               << "response code: " << (int)error.GetResponseCode() << ", message: " << error.GetMessage());
+    return ret;
+  }
+#endif
+
+  long CalculateDelayBeforeNextRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &error, long attemptedRetries) const
+  {
+    auto ret = Aws::Client::DefaultRetryStrategy::CalculateDelayBeforeNextRetry(error, attemptedRetries);
+    auto should_sleep = ShouldRetry(error, attemptedRetries) && ret > 0;
+#if EXTENSIVE_AWS_LOGS > 0
+    std::ostringstream str;
+    str << "retryStrategy::CalculateDelayBeforeNextRetry(" << attemptedRetries << "), error: " << (int)error.GetResponseCode() << ": " << error.GetMessage();
+    if (should_sleep)
+      str << ", sleeping for " << ret << " milliseconds";
+    anon_log(str.str());
+#endif
+    if (should_sleep)
+      fiber::msleep(ret);
+    return 0;
+  }
+};
+
+const char EC2_METADATA_CLIENT_LOG_TAG[] = "EC2MetadataClient";
+const char EC2_SECURITY_CREDENTIALS_RESOURCE[] = "/latest/meta-data/iam/security-credentials";
+const char EC2_IMDS_TOKEN_RESOURCE[] = "/latest/api/token";
+const char EC2_IMDS_TOKEN_TTL_DEFAULT_VALUE[] = "21600";
+const char EC2_IMDS_TOKEN_TTL_HEADER[] = "x-aws-ec2-metadata-token-ttl-seconds";
+const char EC2_IMDS_TOKEN_HEADER[] = "x-aws-ec2-metadata-token";
+const char EC2_REGION_RESOURCE[] = "/latest/meta-data/placement/availability-zone";
+
+class fiberEC2MetadataClient : public Aws::Internal::EC2MetadataClient
+{
+public:
+  fiberEC2MetadataClient(const char *endpoint = "http://169.254.169.254")
+      : Aws::Internal::EC2MetadataClient(EC2_METADATA_CLIENT_LOG_TAG),
+        m_endpoint(endpoint),
+        m_tokenRequired(true)
+  {
+  }
+
+  fiberEC2MetadataClient(const Aws::Client::ClientConfiguration &clientConfiguration, const char *endpoint = "http://169.254.169.254")
+      : Aws::Internal::EC2MetadataClient(clientConfiguration, EC2_METADATA_CLIENT_LOG_TAG),
+        m_endpoint(endpoint),
+        m_tokenRequired(true)
+  {
+  }
+
+  fiberEC2MetadataClient &operator=(const fiberEC2MetadataClient &rhs) = delete;
+  fiberEC2MetadataClient(const fiberEC2MetadataClient &rhs) = delete;
+  fiberEC2MetadataClient &operator=(const fiberEC2MetadataClient &&rhs) = delete;
+  fiberEC2MetadataClient(const fiberEC2MetadataClient &&rhs) = delete;
+
+  virtual ~fiberEC2MetadataClient()
+  {
+  }
+
+  using AWSHttpResourceClient::GetResource;
+
+  virtual Aws::String GetResource(const char *resourcePath) const
+  {
+    return GetResource(m_endpoint.c_str(), resourcePath, nullptr /*authToken*/);
+  }
+
+  virtual Aws::String GetDefaultCredentials() const
+  {
+    auto ths = const_cast<fiberEC2MetadataClient*>(this);
+    fiber_lock locker(ths->m_tokenMutex);
+    if (m_tokenRequired)
     {
+      locker.unlock();
+      return GetDefaultCredentialsSecurely();
     }
 
-    #if EXTENSIVE_AWS_LOGS > 0
-    bool ShouldRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &error, long attemptedRetries) const
-    {
-        auto ret = Aws::Client::DefaultRetryStrategy::ShouldRetry(error, attemptedRetries);
-        if (ret)
-          anon_log("retryStrategy::ShouldRetry(\"" << error.GetExceptionName() << "\"," << attemptedRetries << ") returning true");
-        else
-          anon_log("retryStrategy::ShouldRetry(\"" << error.GetExceptionName() << "\"," << attemptedRetries << ") returning false, "
-            << "response code: " << (int)error.GetResponseCode() << ", message: " << error.GetMessage());
-        return ret;
-    }
-    #endif
+    AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "Getting default credentials for ec2 instance");
+    auto result = GetResourceWithAWSWebServiceResult(m_endpoint.c_str(), EC2_SECURITY_CREDENTIALS_RESOURCE, nullptr);
+    Aws::String credentialsString = result.GetPayload();
+    auto httpResponseCode = result.GetResponseCode();
 
-    long CalculateDelayBeforeNextRetry(const Aws::Client::AWSError<Aws::Client::CoreErrors> &error, long attemptedRetries) const
+    // Note, if service is insane, it might return 404 for our initial secure call,
+    // then when we fall back to insecure call, it might return 401 ask for secure call,
+    // Then, SDK might get into a recursive loop call situation between secure and insecure call.
+    if (httpResponseCode == Aws::Http::HttpResponseCode::UNAUTHORIZED)
     {
-        auto ret = Aws::Client::DefaultRetryStrategy::CalculateDelayBeforeNextRetry(error, attemptedRetries);
-        auto should_sleep = ShouldRetry(error, attemptedRetries) && ret > 0;
-        #if EXTENSIVE_AWS_LOGS > 0
-        std::ostringstream str;
-        str << "retryStrategy::CalculateDelayBeforeNextRetry(" << attemptedRetries << "), error: " << (int)error.GetResponseCode() << ": " << error.GetMessage();
-        if (should_sleep)
-          str << ", sleeping for " << ret << " milliseconds";
-        anon_log(str.str());
-        #endif
-        if (should_sleep)
-          fiber::msleep(ret);
-        return 0;
+      m_tokenRequired = true;
+      return {};
     }
+    locker.unlock();
+
+    Aws::String trimmedCredentialsString = Aws::Utils::StringUtils::Trim(credentialsString.c_str());
+    if (trimmedCredentialsString.empty())
+      return {};
+
+    Aws::Vector<Aws::String> securityCredentials = Aws::Utils::StringUtils::Split(trimmedCredentialsString, '\n');
+
+    AWS_LOGSTREAM_DEBUG(m_logtag.c_str(), "Calling EC2MetadataService resource, " << EC2_SECURITY_CREDENTIALS_RESOURCE
+                                                                                  << " returned credential string " << trimmedCredentialsString);
+
+    if (securityCredentials.size() == 0)
+    {
+      AWS_LOGSTREAM_WARN(m_logtag.c_str(), "Initial call to ec2Metadataservice to get credentials failed");
+      return {};
+    }
+
+    Aws::StringStream ss;
+    ss << EC2_SECURITY_CREDENTIALS_RESOURCE << "/" << securityCredentials[0];
+    AWS_LOGSTREAM_DEBUG(m_logtag.c_str(), "Calling EC2MetadataService resource " << ss.str());
+    return GetResource(ss.str().c_str());
+  }
+
+  virtual Aws::String GetDefaultCredentialsSecurely() const
+  {
+    auto ths = const_cast<fiberEC2MetadataClient*>(this);
+    fiber_lock locker(ths->m_tokenMutex);
+    if (!m_tokenRequired)
+    {
+      locker.unlock();
+      return GetDefaultCredentials();
+    }
+
+    Aws::StringStream ss;
+    ss << m_endpoint << EC2_IMDS_TOKEN_RESOURCE;
+    std::shared_ptr<Aws::Http::HttpRequest> tokenRequest(Aws::Http::CreateHttpRequest(ss.str(), Aws::Http::HttpMethod::HTTP_PUT,
+                                                                Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+    tokenRequest->SetHeaderValue(EC2_IMDS_TOKEN_TTL_HEADER, EC2_IMDS_TOKEN_TTL_DEFAULT_VALUE);
+    auto userAgentString = Aws::Client::ComputeUserAgentString();
+    tokenRequest->SetUserAgent(userAgentString);
+    AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "Calling EC2MetadataService to get token");
+    auto result = GetResourceWithAWSWebServiceResult(tokenRequest);
+    Aws::String tokenString = result.GetPayload();
+    Aws::String trimmedTokenString = Aws::Utils::StringUtils::Trim(tokenString.c_str());
+
+    if (result.GetResponseCode() == Aws::Http::HttpResponseCode::BAD_REQUEST)
+    {
+      return {};
+    }
+    else if (result.GetResponseCode() != Aws::Http::HttpResponseCode::OK || trimmedTokenString.empty())
+    {
+      m_tokenRequired = false;
+      AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "Calling EC2MetadataService to get token failed, falling back to less secure way.");
+      return GetDefaultCredentials();
+    }
+    m_token = trimmedTokenString;
+    locker.unlock();
+    ss.str("");
+    ss << m_endpoint << EC2_SECURITY_CREDENTIALS_RESOURCE;
+    std::shared_ptr<Aws::Http::HttpRequest> profileRequest(Aws::Http::CreateHttpRequest(ss.str(), Aws::Http::HttpMethod::HTTP_GET,
+                                                                  Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+    profileRequest->SetHeaderValue(EC2_IMDS_TOKEN_HEADER, trimmedTokenString);
+    profileRequest->SetUserAgent(userAgentString);
+    Aws::String profileString = GetResourceWithAWSWebServiceResult(profileRequest).GetPayload();
+
+    Aws::String trimmedProfileString = Aws::Utils::StringUtils::Trim(profileString.c_str());
+    Aws::Vector<Aws::String> securityCredentials = Aws::Utils::StringUtils::Split(trimmedProfileString, '\n');
+
+    AWS_LOGSTREAM_DEBUG(m_logtag.c_str(), "Calling EC2MetadataService resource, " << EC2_SECURITY_CREDENTIALS_RESOURCE
+                                                                                  << " with token returned profile string " << trimmedProfileString);
+    if (securityCredentials.size() == 0)
+    {
+      AWS_LOGSTREAM_WARN(m_logtag.c_str(), "Calling EC2Metadataservice to get profiles failed");
+      return {};
+    }
+
+    ss.str("");
+    ss << m_endpoint << EC2_SECURITY_CREDENTIALS_RESOURCE << "/" << securityCredentials[0];
+    std::shared_ptr<Aws::Http::HttpRequest> credentialsRequest(Aws::Http::CreateHttpRequest(ss.str(), Aws::Http::HttpMethod::HTTP_GET,
+                                                                      Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+    credentialsRequest->SetHeaderValue(EC2_IMDS_TOKEN_HEADER, trimmedTokenString);
+    credentialsRequest->SetUserAgent(userAgentString);
+    AWS_LOGSTREAM_DEBUG(m_logtag.c_str(), "Calling EC2MetadataService resource " << ss.str() << " with token.");
+    return GetResourceWithAWSWebServiceResult(credentialsRequest).GetPayload();
+  }
+
+  virtual Aws::String GetCurrentRegion() const
+  {
+    AWS_LOGSTREAM_TRACE(m_logtag.c_str(), "Getting current region for ec2 instance");
+
+    Aws::StringStream ss;
+    ss << m_endpoint << EC2_REGION_RESOURCE;
+    std::shared_ptr<Aws::Http::HttpRequest> regionRequest(Aws::Http::CreateHttpRequest(ss.str(), Aws::Http::HttpMethod::HTTP_GET,
+                                                                 Aws::Utils::Stream::DefaultResponseStreamFactoryMethod));
+    {
+      auto ths = const_cast<fiberEC2MetadataClient*>(this);
+      fiber_lock locker(ths->m_tokenMutex);
+      if (m_tokenRequired)
+      {
+        regionRequest->SetHeaderValue(EC2_IMDS_TOKEN_HEADER, m_token);
+      }
+    }
+    regionRequest->SetUserAgent(Aws::Client::ComputeUserAgentString());
+    Aws::String azString = GetResourceWithAWSWebServiceResult(regionRequest).GetPayload();
+
+    if (azString.empty())
+    {
+      AWS_LOGSTREAM_INFO(m_logtag.c_str(),
+                         "Unable to pull region from instance metadata service ");
+      return {};
+    }
+
+    Aws::String trimmedAZString = Aws::Utils::StringUtils::Trim(azString.c_str());
+    AWS_LOGSTREAM_DEBUG(m_logtag.c_str(), "Calling EC2MetadataService resource "
+                                              << EC2_REGION_RESOURCE << " , returned credential string " << trimmedAZString);
+
+    Aws::String region;
+    region.reserve(trimmedAZString.length());
+
+    bool digitFound = false;
+    for (auto character : trimmedAZString)
+    {
+      if (digitFound && !isdigit(character))
+      {
+        break;
+      }
+      if (isdigit(character))
+      {
+        digitFound = true;
+      }
+
+      region.append(1, character);
+    }
+
+    AWS_LOGSTREAM_INFO(m_logtag.c_str(), "Detected current region as " << region);
+    return region;
+  }
+
+private:
+  Aws::String m_endpoint;
+  fiber_mutex m_tokenMutex;
+  mutable Aws::String m_token;
+  mutable bool m_tokenRequired;
 };
 
 // the implementation of this class in Aws itself (InstanceProfileCredentialsProvider)
 // is intended to run when the code finds itself running on an ec2 instance.  But that
 // implementation locks a system mutex around http api calls, which we don't permit in
 // anon.  So this reimplements that class using fiber mutexes intead.
-static const char* INSTANCE_LOG_TAG = "fiberInstanceProfileCredentialsProvider";
+static const char *INSTANCE_LOG_TAG = "fiberInstanceProfileCredentialsProvider";
 
 class fiberInstanceProfileCredentialsProvider : public Aws::Auth::AWSCredentialsProvider
 {
 public:
   fiberInstanceProfileCredentialsProvider(long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD)
-    : m_ec2MetadataConfigLoader(Aws::MakeShared<Aws::Config::EC2InstanceProfileConfigLoader>(INSTANCE_LOG_TAG)),
-      m_loadFrequencyMs(refreshRateMs)
+      : //m_ec2MetadataConfigLoader(Aws::MakeShared<Aws::Config::EC2InstanceProfileConfigLoader>(std::static_pointer_cast<Aws::Internal::EC2MetadataClient>(std::make_shared<fiberEC2MetadataClient>()))),
+        m_loadFrequencyMs(refreshRateMs)
   {
+    auto metaClient = std::static_pointer_cast<Aws::Internal::EC2MetadataClient>(std::make_shared<fiberEC2MetadataClient>());
+    auto loader = std::make_shared<Aws::Config::EC2InstanceProfileConfigLoader>(metaClient);
+    m_ec2MetadataConfigLoader = loader;
   }
 
-  fiberInstanceProfileCredentialsProvider(const std::shared_ptr<Aws::Config::EC2InstanceProfileConfigLoader>& loader, long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD)
-    : m_ec2MetadataConfigLoader(loader),
-      m_loadFrequencyMs(refreshRateMs)
+  fiberInstanceProfileCredentialsProvider(const std::shared_ptr<Aws::Config::EC2InstanceProfileConfigLoader> &loader, long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD)
+      : m_ec2MetadataConfigLoader(loader),
+        m_loadFrequencyMs(refreshRateMs)
   {
   }
 
@@ -223,7 +447,7 @@ public:
     AddProvider(Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>(defaultFiberCredentialsProviderChainTag));
     AddProvider(Aws::MakeShared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>(defaultFiberCredentialsProviderChainTag));
     AddProvider(Aws::MakeShared<Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider>(defaultFiberCredentialsProviderChainTag));
-    
+
     //ECS TaskRole Credentials only available when ENVIRONMENT VARIABLE is set
     const auto relativeUri = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_CREDENTIALS_RELATIVE_URI);
 
@@ -233,17 +457,17 @@ public:
 
     if (!relativeUri.empty())
     {
-        AddProvider(Aws::MakeShared<Aws::Auth::TaskRoleCredentialsProvider>(defaultFiberCredentialsProviderChainTag, relativeUri.c_str()));
+      AddProvider(Aws::MakeShared<Aws::Auth::TaskRoleCredentialsProvider>(defaultFiberCredentialsProviderChainTag, relativeUri.c_str()));
     }
     else if (!absoluteUri.empty())
     {
-        const auto token = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN);
-        AddProvider(Aws::MakeShared<Aws::Auth::TaskRoleCredentialsProvider>(defaultFiberCredentialsProviderChainTag,
-                    absoluteUri.c_str(), token.c_str()));
+      const auto token = Aws::Environment::GetEnv(AWS_ECS_CONTAINER_AUTHORIZATION_TOKEN);
+      AddProvider(Aws::MakeShared<Aws::Auth::TaskRoleCredentialsProvider>(defaultFiberCredentialsProviderChainTag,
+                                                                          absoluteUri.c_str(), token.c_str()));
     }
     else if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true")
     {
-        AddProvider(Aws::MakeShared<fiberInstanceProfileCredentialsProvider>(defaultFiberCredentialsProviderChainTag));
+      AddProvider(Aws::MakeShared<fiberInstanceProfileCredentialsProvider>(defaultFiberCredentialsProviderChainTag));
     }
   }
 };
@@ -353,10 +577,10 @@ extern "C" int main(int argc, char **argv)
 #ifdef TEFLON_AWS
   Aws::SDKOptions aws_options;
   aws_options.httpOptions.httpClientFactory_create_fn = [] { return std::static_pointer_cast<Aws::Http::HttpClientFactory>(std::make_shared<aws_http_client_factory>()); };
-  #if EXTENSIVE_AWS_LOGS > 1
+#if EXTENSIVE_AWS_LOGS > 1
   aws_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Info;
   aws_options.loggingOptions.logger_create_fn = [] { return std::static_pointer_cast<Aws::Utils::Logging::LogSystemInterface>(std::make_shared<logger>()); };
-  #endif
+#endif
   Aws::InitAPI(aws_options);
   Aws::Client::ClientConfiguration client_cfg;
 

--- a/src/cpp/aws_http.cpp
+++ b/src/cpp/aws_http.cpp
@@ -124,7 +124,9 @@ public:
       MakeRequest(resp, request, request.GetUri(), readLimiter, writeLimiter, 0);
     }
     catch(const fiber_io_error &exc) {
+#if ANON_LOG_NET_TRAFFIC > 0
       anon_log("filber_io_error: " << exc.what());
+#endif
       resp->SetResponseCode(HttpResponseCode::NETWORK_CONNECT_TIMEOUT); // set to "timeout" so the sdk performs a retry, see HttpResponseCode::IsRetryableHttpResponseCode
     }
 #if ANON_LOG_NET_TRAFFIC > 0


### PR DESCRIPTION
This basically replicates the implementation of Aws::Internal::EC2MetadataClient - except that it doesn't lock any system mutex's across the http calls that the implementation uses to read the metadata about the ec2 instance.  Without this (so using the original EC2MetadataClient class) it would sometimes deadlock during startup.  This code needs a big rewrite...