### PR TITLE
Cors options

### DIFF
--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -197,7 +197,7 @@ void request_dispatcher::dispatch(http_server::pipe_t &pipe, const http_request 
         throw_request_error(HTTP_STATUS_BAD_REQUEST, "OPTIONS request missing required access-control-request-method header");
       method = request.headers.get_header("access-control-request-method").str();
     }
-    auto m = _map.find(request.method_str());
+    auto m = _map.find(method);
     if (m == _map.end())
       throw_request_error(HTTP_STATUS_METHOD_NOT_ALLOWED, "method: " << method);
     auto query = request.get_url_field(UF_QUERY);

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -176,7 +176,7 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request)
   http_response response;
   response.add_header("access-control-allow-origin", "*");
   std::ostringstream oss;
-  oss << "OPTIONS, " << request.method_str();
+  oss << "OPTIONS, " << request.headers.get_header("access-control-request-method").str();
   response.add_header("access-control-allow-methods", oss.str());
   response.add_header("access-control-allow-headers", "*");
   response.set_status_code("204 No Content"); 

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -81,7 +81,7 @@ request_helper request_mapping_helper(const std::string &path_spec)
   return h;
 }
 
-std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query)
+std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query, bool is_options)
 {
   auto ret = std::make_pair(false, std::vector<std::string>());
 
@@ -156,7 +156,7 @@ std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h
     }
   }
 
-  if (h.header_items.size() > 0)
+  if (!is_options && h.header_items.size() > 0)
   {
     for (auto &it : h.header_items)
     {

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -171,22 +171,12 @@ std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h
   return ret;
 }
 
-void respond_options(http_server::pipe_t &pipe, const http_request &request, int cors_enabled)
+void respond_options(http_server::pipe_t &pipe, const http_request &request)
 {
   http_response response;
   response.add_header("access-control-allow-origin", "*");
   std::ostringstream oss;
-  oss << "OPTIONS";
-  if (cors_enabled & request_dispatcher::k_enable_cors_get)
-    oss << ", GET";
-  if (cors_enabled & request_dispatcher::k_enable_cors_head)
-    oss << ", HEAD";
-  if (cors_enabled & request_dispatcher::k_enable_cors_post)
-    oss << ", POST";
-  if (cors_enabled & request_dispatcher::k_enable_cors_put)
-    oss << ", PUT";
-  if (cors_enabled & request_dispatcher::k_enable_cors_delete)
-    oss << ", DELETE";
+  oss << "OPTIONS, " << request.method_str();
   response.add_header("access-control-allow-methods", oss.str());
   response.add_header("access-control-allow-headers", "*");
   response.set_status_code("204 No Content"); 
@@ -247,7 +237,7 @@ void request_dispatcher::dispatch(http_server::pipe_t &pipe, const http_request 
     --e;
     for (auto &f : e->second)
     {
-      if (f(pipe, request, is_tls, path, query, is_options, _cors_enabled))
+      if (f(pipe, request, is_tls, path, query, is_options))
         return;
     }
     throw_request_error(HTTP_STATUS_NOT_FOUND, "resource: \"" << path << "\" not found (2)");

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -171,25 +171,48 @@ std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h
   return ret;
 }
 
+void respond_options(http_server::pipe_t &pipe, const http_request &request, int cors_enabled)
+{
+  http_response response;
+  response.add_header("access-control-allow-origin", "*");
+  std::ostringstream oss;
+  oss << "OPTIONS";
+  if (cors_enabled & request_dispatcher::k_enable_cors_get)
+    oss << ", GET";
+  if (cors_enabled & request_dispatcher::k_enable_cors_head)
+    oss << ", HEAD";
+  if (cors_enabled & request_dispatcher::k_enable_cors_post)
+    oss << ", POST";
+  if (cors_enabled & request_dispatcher::k_enable_cors_put)
+    oss << ", PUT";
+  if (cors_enabled & request_dispatcher::k_enable_cors_delete)
+    oss << ", DELETE";
+  response.add_header("access-control-allow-methods", oss.str());
+  response.add_header("access-control-allow-headers", "*");
+  response.set_status_code("204 No Content"); 
+  pipe.respond(response);
+}
+
+
 void request_dispatcher::dispatch(http_server::pipe_t &pipe, const http_request &request, bool is_tls)
 {
   request_wrap(pipe, [this, &pipe, &request, is_tls] {
     std::string method = request.method_str();
-    bool is_options = (_enable_cors != 0) && (_options == method);
+    bool is_options = (_cors_enabled != 0) && (_options == method);
     auto path = request.get_url_field(UF_PATH);
     if (is_options) {
       if (path == "*" || path == "") {
         std::ostringstream oss;
         oss << "OPTIONS";
-        if (_enable_cors & k_enable_cors_get)
+        if (_cors_enabled & k_enable_cors_get)
           oss << ", GET";
-        if (_enable_cors & k_enable_cors_head)
+        if (_cors_enabled & k_enable_cors_head)
           oss << ", HEAD";
-        if (_enable_cors & k_enable_cors_post)
+        if (_cors_enabled & k_enable_cors_post)
           oss << ", POST";
-        if (_enable_cors & k_enable_cors_put)
+        if (_cors_enabled & k_enable_cors_put)
           oss << ", PUT";
-        if (_enable_cors & k_enable_cors_delete)
+        if (_cors_enabled & k_enable_cors_delete)
           oss << ", DELETE";
         http_response response;
         response.add_header("allow", oss.str());
@@ -202,15 +225,15 @@ void request_dispatcher::dispatch(http_server::pipe_t &pipe, const http_request 
       method = request.headers.get_header("access-control-request-method").str();
       bool chk = false;
       if (method == "GET")
-        chk = _enable_cors & k_enable_cors_get;
+        chk = _cors_enabled & k_enable_cors_get;
       else if (method == "HEAD")
-        chk = _enable_cors & k_enable_cors_head;
+        chk = _cors_enabled & k_enable_cors_head;
       else if (method == "POST")
-        chk = _enable_cors & k_enable_cors_post;
+        chk = _cors_enabled & k_enable_cors_post;
       else if (method == "PUT")
-        chk = _enable_cors & k_enable_cors_put;
+        chk = _cors_enabled & k_enable_cors_put;
       else if (method == "DELETE")
-        chk = _enable_cors & k_enable_cors_put;
+        chk = _cors_enabled & k_enable_cors_put;
       if (!chk)
         throw_request_error(HTTP_STATUS_METHOD_NOT_ALLOWED, "method: " << method);
     }
@@ -224,7 +247,7 @@ void request_dispatcher::dispatch(http_server::pipe_t &pipe, const http_request 
     --e;
     for (auto &f : e->second)
     {
-      if (f(pipe, request, is_tls, path, query, is_options))
+      if (f(pipe, request, is_tls, path, query, is_options, _cors_enabled))
         return;
     }
     throw_request_error(HTTP_STATUS_NOT_FOUND, "resource: \"" << path << "\" not found (2)");

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -179,6 +179,7 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request)
   oss << "OPTIONS, " << request.headers.get_header("access-control-request-method").str();
   response.add_header("access-control-allow-methods", oss.str());
   response.add_header("access-control-allow-headers", "*");
+  response.add_header("cache-control", "max-age=604800");
   response.set_status_code("204 No Content"); 
   pipe.respond(response);
 }
@@ -206,7 +207,8 @@ void request_dispatcher::dispatch(http_server::pipe_t &pipe, const http_request 
           oss << ", DELETE";
         http_response response;
         response.add_header("allow", oss.str());
-        response.set_status_code("204 No Content"); 
+        response.add_header("cache-control", "max-age=604800");
+        response.set_status_code("204 No Content");
         pipe.respond(response);
         return;
       }

--- a/src/cpp/request_dispatcher.h
+++ b/src/cpp/request_dispatcher.h
@@ -238,7 +238,7 @@
  */
 class request_dispatcher
 {
-  std::map<std::string, std::map<std::string, std::vector<std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>>>> _map;
+  std::map<std::string, std::map<std::string, std::vector<std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>>>> _map;
   pcrecpp::RE _split_at_var;
   std::string _root_path;
   std::string _options;

--- a/src/cpp/request_dispatcher.h
+++ b/src/cpp/request_dispatcher.h
@@ -242,20 +242,23 @@ class request_dispatcher
   pcrecpp::RE _split_at_var;
   std::string _root_path;
   std::string _options;
-  bool _enable_cors_get;
-  bool _enable_cors_head;
-  bool _enable_cors_put;
-  bool _enable_cors;
+  int _enable_cors;
 
 public:
-  request_dispatcher(const std::string &root_path, bool enable_cors_get = false, bool enable_cors_head = false, bool enable_cors_put = false)
+  enum {
+    k_enable_cors_get = 1,
+    k_enable_cors_head = 2,
+    k_enable_cors_post = 4,
+    k_enable_cors_put = 8,
+    k_enable_cors_delete = 16,
+    k_enable_cors_all = 31
+  };
+
+  request_dispatcher(const std::string &root_path, int enable_cors = 0)
       : _split_at_var("([^?{]*)(.*)"),
         _root_path(root_path),
         _options("OPTIONS"),
-        _enable_cors_get(enable_cors_get),
-        _enable_cors_head(enable_cors_head),
-        _enable_cors_put(enable_cors_put),
-        _enable_cors(enable_cors_get || enable_cors_head || _enable_cors_put)
+        _enable_cors(enable_cors)
   {
   }
 

--- a/src/cpp/request_dispatcher.h
+++ b/src/cpp/request_dispatcher.h
@@ -238,14 +238,24 @@
  */
 class request_dispatcher
 {
-  std::map<std::string, std::map<std::string, std::vector<std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>>>> _map;
+  std::map<std::string, std::map<std::string, std::vector<std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>>>> _map;
   pcrecpp::RE _split_at_var;
   std::string _root_path;
+  std::string _options;
+  bool _enable_cors_get;
+  bool _enable_cors_head;
+  bool _enable_cors_put;
+  bool _enable_cors;
 
 public:
-  request_dispatcher(const std::string &root_path)
+  request_dispatcher(const std::string &root_path, bool enable_cors_get = false, bool enable_cors_head = false, bool enable_cors_put = false)
       : _split_at_var("([^?{]*)(.*)"),
-        _root_path(root_path)
+        _root_path(root_path),
+        _options("OPTIONS"),
+        _enable_cors_get(enable_cors_get),
+        _enable_cors_head(enable_cors_head),
+        _enable_cors_put(enable_cors_put),
+        _enable_cors(enable_cors_get || enable_cors_head || _enable_cors_put)
   {
   }
 

--- a/src/cpp/request_dispatcher.h
+++ b/src/cpp/request_dispatcher.h
@@ -238,11 +238,11 @@
  */
 class request_dispatcher
 {
-  std::map<std::string, std::map<std::string, std::vector<std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>>>> _map;
+  std::map<std::string, std::map<std::string, std::vector<std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>>>> _map;
   pcrecpp::RE _split_at_var;
   std::string _root_path;
   std::string _options;
-  int _enable_cors;
+  int _cors_enabled;
 
 public:
   enum {
@@ -254,11 +254,11 @@ public:
     k_enable_cors_all = 31
   };
 
-  request_dispatcher(const std::string &root_path, int enable_cors = 0)
+  request_dispatcher(const std::string &root_path, int cors_enabled = 0)
       : _split_at_var("([^?{]*)(.*)"),
         _root_path(root_path),
         _options("OPTIONS"),
-        _enable_cors(enable_cors)
+        _cors_enabled(cors_enabled)
   {
   }
 

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -63,7 +63,7 @@ void body_as_json(http_server::pipe_t &pipe, const http_request &request, Fn f, 
 inline void respond_options(http_server::pipe_t &pipe, const http_request &request)
 {
   http_response response;
-  response.add_header("allow", request.headers.get_header("access-control-request-method").ptr());
+  response.add_header("allow", request.headers.get_header("access-control-request-method").str());
   response.set_status_code("204 No Content"); 
   pipe.respond(response);
 }

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -60,13 +60,7 @@ void body_as_json(http_server::pipe_t &pipe, const http_request &request, Fn f, 
   f(pipe, request, std::forward<Args>(args)..., body);
 }
 
-inline void respond_options(http_server::pipe_t &pipe, const http_request &request)
-{
-  http_response response;
-  response.add_header("allow", request.headers.get_header("access-control-request-method").str());
-  response.set_status_code("204 No Content"); 
-  pipe.respond(response);
-}
+void respond_options(http_server::pipe_t &pipe, const http_request &request, int cors_enabled);
 
 #define n_pipe *(http_server::pipe_t *)0
 #define n_request *(http_request *)0
@@ -76,14 +70,14 @@ inline void respond_options(http_server::pipe_t &pipe, const http_request &reque
 std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query, bool is_options);
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       f(pipe, request);
     return true;
@@ -91,14 +85,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       f(pipe, request, params.second[0]);
     return true;
@@ -106,14 +100,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       f(pipe, request, params.second[0], params.second[1]);
     return true;
@@ -121,14 +115,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       f(pipe, request, params.second[0], params.second[1], params.second[2]);
     return true;
@@ -136,14 +130,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
@@ -151,14 +145,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
@@ -166,14 +160,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       body_as_json(pipe, request, f);
     return true;
@@ -181,14 +175,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       body_as_json(pipe, request, f, params.second[0]);
     return true;
@@ -196,14 +190,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1]);
     return true;
@@ -211,14 +205,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2]);
     return true;
@@ -226,14 +220,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
@@ -241,14 +235,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, cors_enabled);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -73,13 +73,13 @@ inline void respond_options(http_server::pipe_t &pipe, const http_request &reque
 #define n_json *(nlohmann::json *)0
 
 
-std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query);
+std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query, bool is_options);
 
 template <typename Fn>
 auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -94,7 +94,7 @@ template <typename Fn>
 auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -109,7 +109,7 @@ template <typename Fn>
 auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -124,7 +124,7 @@ template <typename Fn>
 auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -139,7 +139,7 @@ template <typename Fn>
 auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -154,7 +154,7 @@ template <typename Fn>
 auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -169,7 +169,7 @@ template <typename Fn>
 auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -184,7 +184,7 @@ template <typename Fn>
 auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -199,7 +199,7 @@ template <typename Fn>
 auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -214,7 +214,7 @@ template <typename Fn>
 auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -229,7 +229,7 @@ template <typename Fn>
 auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
@@ -244,7 +244,7 @@ template <typename Fn>
 auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
   return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
-    auto params = extract_params(h, request, path, query);
+    auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -60,152 +60,197 @@ void body_as_json(http_server::pipe_t &pipe, const http_request &request, Fn f, 
   f(pipe, request, std::forward<Args>(args)..., body);
 }
 
+inline void respond_options(http_server::pipe_t &pipe, const http_request &request)
+{
+  http_response response;
+  response.add_header("Allow", request.method_str());
+  response.set_status_code("204 No Content"); 
+  pipe.respond(response);
+}
+
 #define n_pipe *(http_server::pipe_t *)0
 #define n_request *(http_request *)0
 #define n_json *(nlohmann::json *)0
 
 
 std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query);
+
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    f(pipe, request);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      f(pipe, request);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    f(pipe, request, params.second[0]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      f(pipe, request, params.second[0]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    f(pipe, request, params.second[0], params.second[1]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      f(pipe, request, params.second[0], params.second[1]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    f(pipe, request, params.second[0], params.second[1], params.second[2]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      f(pipe, request, params.second[0], params.second[1], params.second[2]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    body_as_json(pipe, request, f);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      body_as_json(pipe, request, f);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    body_as_json(pipe, request, f, params.second[0]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      body_as_json(pipe, request, f, params.second[0]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    body_as_json(pipe, request, f, params.second[0], params.second[1]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      body_as_json(pipe, request, f, params.second[0], params.second[1]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query);
     if (!params.first)
       return false;
-    body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
+    if (is_options)
+      respond_options(pipe, request);
+    else
+      body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
   };
 }

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -63,7 +63,7 @@ void body_as_json(http_server::pipe_t &pipe, const http_request &request, Fn f, 
 inline void respond_options(http_server::pipe_t &pipe, const http_request &request)
 {
   http_response response;
-  response.add_header("Allow", request.method_str());
+  response.add_header("allow", request.headers.get_header("access-control-request-method").ptr());
   response.set_status_code("204 No Content"); 
   pipe.respond(response);
 }

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -60,7 +60,7 @@ void body_as_json(http_server::pipe_t &pipe, const http_request &request, Fn f, 
   f(pipe, request, std::forward<Args>(args)..., body);
 }
 
-void respond_options(http_server::pipe_t &pipe, const http_request &request, int cors_enabled);
+void respond_options(http_server::pipe_t &pipe, const http_request &request);
 
 #define n_pipe *(http_server::pipe_t *)0
 #define n_request *(http_request *)0
@@ -70,14 +70,14 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request, int
 std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query, bool is_options);
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool, int)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       f(pipe, request);
     return true;
@@ -85,14 +85,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       f(pipe, request, params.second[0]);
     return true;
@@ -100,14 +100,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       f(pipe, request, params.second[0], params.second[1]);
     return true;
@@ -115,14 +115,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       f(pipe, request, params.second[0], params.second[1], params.second[2]);
     return true;
@@ -130,14 +130,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
@@ -145,14 +145,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
@@ -160,14 +160,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       body_as_json(pipe, request, f);
     return true;
@@ -175,14 +175,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       body_as_json(pipe, request, f, params.second[0]);
     return true;
@@ -190,14 +190,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1]);
     return true;
@@ -205,14 +205,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2]);
     return true;
@@ -220,14 +220,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
@@ -235,14 +235,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool, int)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options, int cors_enabled) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request, cors_enabled);
+      respond_options(pipe, request);
     else
       body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;


### PR DESCRIPTION
Allow the client to specify semi-normal CORS behavior by asking for it when creating the request_dispatcher.  Once requested, the behavior is all automatic in request_dispatcher itself.