### PR TITLE
Route tls

### DIFF
--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -171,7 +171,7 @@ std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h
   return ret;
 }
 
-void respond_options(http_server::pipe_t &pipe, const http_request &request)
+void respond_options(http_server::pipe_t &pipe, const http_request &request, const std::vector<std::string>& allowed_headers)
 {
   http_response response;
   auto orig = request.headers.get_header("origin");
@@ -180,7 +180,18 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request)
   std::ostringstream oss;
   oss << "OPTIONS, " << request.headers.get_header("access-control-request-method").str();
   response.add_header("access-control-allow-methods", oss.str());
-  response.add_header("access-control-allow-headers", "content-type, authorization");
+  if (allowed_headers.size() > 0) {
+    std::ostringstream oss;
+    auto is_first = true;
+    for (auto &h : allowed_headers) {
+      if (is_first)
+        is_first = false;
+      else
+        oss << ", ";
+      oss << h;
+    }
+    response.add_header("access-control-allow-headers", oss.str());
+  }
   response.add_header("access-control-allow-credentials", "true");
   response.add_header("cache-control", "max-age=604800");
   response.set_status_code("204 No Content"); 

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -180,7 +180,7 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request)
   std::ostringstream oss;
   oss << "OPTIONS, " << request.headers.get_header("access-control-request-method").str();
   response.add_header("access-control-allow-methods", oss.str());
-  response.add_header("access-control-allow-headers", "*");
+  response.add_header("access-control-allow-headers", "content-type, authorization");
   response.add_header("access-control-allow-credentials", "true");
   response.add_header("cache-control", "max-age=604800");
   response.set_status_code("204 No Content"); 

--- a/src/cpp/request_dispatcher.cpp
+++ b/src/cpp/request_dispatcher.cpp
@@ -177,9 +177,7 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request, con
   auto orig = request.headers.get_header("origin");
   auto orig2 = orig.len() > 0 ? orig.str() : std::string("*");
   response.add_header("access-control-allow-origin", orig2);
-  std::ostringstream oss;
-  oss << "OPTIONS, " << request.headers.get_header("access-control-request-method").str();
-  response.add_header("access-control-allow-methods", oss.str());
+  response.add_header("access-control-allow-methods", request.headers.get_header("access-control-request-method").str());
   if (allowed_headers.size() > 0) {
     std::ostringstream oss;
     auto is_first = true;

--- a/src/cpp/request_dispatcher.h
+++ b/src/cpp/request_dispatcher.h
@@ -45,7 +45,7 @@
  *    rd.request_mapping(
  *        "GET",
  *        "hello",
- *        [](http_server::pipe_t &pipe, const http_request &request){
+ *        [](http_server::pipe_t &pipe, const http_request &request, bool is_tls){
  *          http_response response;
  *          response.add_header("content-type", "text/plain");
  *          response << "myapi says hello\n";
@@ -71,7 +71,7 @@
  *    rd.request_mapping(
  *        "GET",
  *        "{client_name}/hello",
- *        [](http_server::pipe_t &pipe, const http_request &request, const std::string& client_name){
+ *        [](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string& client_name){
  *          http_response response;
  *          response.add_header("content-type", "text/plain");
  *          response << "hi " << client_name << ", how's it going?\n";

--- a/src/cpp/request_dispatcher.h
+++ b/src/cpp/request_dispatcher.h
@@ -254,23 +254,25 @@ public:
   }
 
   template <typename Fn>
-  void request_mapping(const std::string &method, const std::string &path_spec, Fn f)
+  void request_mapping(const std::string &method, const std::string &path_spec, Fn f,
+     const std::vector<std::string>& allowed_headers = std::vector<std::string>())
   {
     auto full_path_spec = _root_path + path_spec;
     std::string non_var, var;
     if (!_split_at_var.FullMatch(full_path_spec, &non_var, &var))
       anon_throw(std::runtime_error, "path split failed, invalid path: " << full_path_spec);
-    _map[method][non_var].push_back(get_map_responder(f, request_mapping_helper(full_path_spec)));
+    _map[method][non_var].push_back(get_map_responder(f, allowed_headers, request_mapping_helper(full_path_spec)));
   }
 
   template <typename Fn>
-  void request_mapping_body(const std::string &method, const std::string &path_spec, Fn f)
+  void request_mapping_body(const std::string &method, const std::string &path_spec, Fn f,
+    const std::vector<std::string>& allowed_headers = std::vector<std::string>())
   {
     auto full_path_spec = _root_path + path_spec;
     std::string non_var, var;
     if (!_split_at_var.FullMatch(full_path_spec, &non_var, &var))
       anon_throw(std::runtime_error, "path split failed, invalid path: " << full_path_spec);
-    _map[method][non_var].push_back(get_map_responder_body(f, request_mapping_helper(full_path_spec)));
+    _map[method][non_var].push_back(get_map_responder_body(f, allowed_headers, request_mapping_helper(full_path_spec)));
   }
 
   void dispatch(http_server::pipe_t &pipe, const http_request &request, bool is_tls);

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -70,181 +70,181 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request);
 std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query, bool is_options);
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      f(pipe, request);
+      f(pipe, request, is_tls);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      f(pipe, request, params.second[0]);
+      f(pipe, request, is_tls, params.second[0]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query,bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query,bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      f(pipe, request, params.second[0], params.second[1]);
+      f(pipe, request, is_tls, params.second[0], params.second[1]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      f(pipe, request, params.second[0], params.second[1], params.second[2]);
+      f(pipe, request, is_tls, params.second[0], params.second[1], params.second[2]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3]);
+      f(pipe, request, is_tls, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      f(pipe, request, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
+      f(pipe, request, is_tls, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      body_as_json(pipe, request, f);
+      body_as_json(pipe, request, is_tls, f);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      body_as_json(pipe, request, f, params.second[0]);
+      body_as_json(pipe, request, is_tls, f, params.second[0]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      body_as_json(pipe, request, f, params.second[0], params.second[1]);
+      body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2]);
+      body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1], params.second[2]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3]);
+      body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
   };
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
       respond_options(pipe, request);
     else
-      body_as_json(pipe, request, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
+      body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
   };
 }

--- a/src/cpp/request_dispatcher_priv.h
+++ b/src/cpp/request_dispatcher_priv.h
@@ -60,7 +60,7 @@ void body_as_json(http_server::pipe_t &pipe, const http_request &request, Fn f, 
   f(pipe, request, std::forward<Args>(args)..., body);
 }
 
-void respond_options(http_server::pipe_t &pipe, const http_request &request);
+void respond_options(http_server::pipe_t &pipe, const http_request &request, const std::vector<std::string>& allowed_headers);
 
 #define n_pipe *(http_server::pipe_t *)0
 #define n_request *(http_request *)0
@@ -70,14 +70,14 @@ void respond_options(http_server::pipe_t &pipe, const http_request &request);
 std::pair<bool, std::vector<std::string>> extract_params(const request_helper &h, const http_request &request, const std::string &path, const std::string &query, bool is_options);
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
+auto get_map_responder(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &s, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       f(pipe, request, is_tls);
     return true;
@@ -85,14 +85,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       f(pipe, request, is_tls, params.second[0]);
     return true;
@@ -100,14 +100,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query,bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query,bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       f(pipe, request, is_tls, params.second[0], params.second[1]);
     return true;
@@ -115,14 +115,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       f(pipe, request, is_tls, params.second[0], params.second[1], params.second[2]);
     return true;
@@ -130,14 +130,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       f(pipe, request, is_tls, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
@@ -145,14 +145,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), std::string())), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       f(pipe, request, is_tls, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;
@@ -160,14 +160,14 @@ auto get_map_responder(Fn f, const request_helper &h) -> decltype((void)(f(n_pip
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       body_as_json(pipe, request, is_tls, f);
     return true;
@@ -175,14 +175,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       body_as_json(pipe, request, is_tls, f, params.second[0]);
     return true;
@@ -190,14 +190,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1]);
     return true;
@@ -205,14 +205,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1], params.second[2]);
     return true;
@@ -220,14 +220,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1], params.second[2], params.second[3]);
     return true;
@@ -235,14 +235,14 @@ auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(
 }
 
 template <typename Fn>
-auto get_map_responder_body(Fn f, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
+auto get_map_responder_body(Fn f, const std::vector<std::string>& allowed_headers, const request_helper &h) -> decltype((void)(f(n_pipe, n_request, false, std::string(), std::string(), std::string(), std::string(), std::string(), n_json)), std::function<bool(http_server::pipe_t &, const http_request &, bool, const std::string &, const std::string &, bool)>())
 {
-  return [f, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
+  return [f, allowed_headers, h](http_server::pipe_t &pipe, const http_request &request, bool is_tls, const std::string &path, const std::string &query, bool is_options) -> bool {
     auto params = extract_params(h, request, path, query, is_options);
     if (!params.first)
       return false;
     if (is_options)
-      respond_options(pipe, request);
+      respond_options(pipe, request, allowed_headers);
     else
       body_as_json(pipe, request, is_tls, f, params.second[0], params.second[1], params.second[2], params.second[3], params.second[4]);
     return true;


### PR DESCRIPTION
Route the "is_tls" boolean down to the function supplied to request_mapping.  Also, allow request_mapping to supply a custom "allow-headers" response to an OPTIONS request for that path.